### PR TITLE
Q2-URL-Fix

### DIFF
--- a/src/Endpunkt.php
+++ b/src/Endpunkt.php
@@ -10,7 +10,7 @@ class Endpunkt
 {
 
 	const Q1 = 'http://ev-q1.tanzsport-portal.de';
-	const Q2 = 'http://ev-e2.tanzsport-portal.de';
+	const Q2 = 'http://ev-q2.tanzsport-portal.de';
 	const PROD = 'https://ev.tanzsport-portal.de';
 
 	/**


### PR DESCRIPTION
Die URL-Konstante in der Endpunkt-Klasse hatte offensichtlich einen kleinen Typo. Dieser ist behoben worden.
