### PR TITLE
CI-Test für PHP 7 und nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ php:
 - 5.4
 - 5.5
 - 5.6
+- 7.0
+- nightly
 - hhvm
-install: composer update
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+install: composer install
 script: php vendor/bin/phpunit
 env:
   global:


### PR DESCRIPTION
Travis-CI testet nun auch auf die neue PHP-stable 7.0 und die nightly-Version, wobei der Test für letztere auch fehlschlagen darf.

Fixes #4 
